### PR TITLE
Allow full nodes names in cluster_nodes

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -9,7 +9,8 @@
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 <% end -%>
 <% if @config_cluster -%>
-    {cluster_nodes, {[<%= @cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
+    {cluster_nodes, {[<%= @cluster_nodes.map { |n| (n.index('@')!=nil)?"\'#{n}\'":"\'rabbit@#{n}\'" }.join(', ') %>], <%= @clu\
+ster_node_type %>}},
     {cluster_partition_handling, <%= @cluster_partition_handling %>},
 <% end -%>
 <%- if @tcp_keepalive -%>


### PR DESCRIPTION
This change allows a full rabbitmq node name including service name to be specified in the cluster_nodes parameter.
Backwards compatibility (prepend 'rabbit@') is maintained unless the node name has an '@' in it, in which case it is used verbatim.